### PR TITLE
correct release info to avoid break lines issue in Github Release

### DIFF
--- a/config/robotframework_aio/release_items_RobotFramework_UDS.json
+++ b/config/robotframework_aio/release_items_RobotFramework_UDS.json
@@ -61,40 +61,38 @@ service names instead of dealing with hex IDs.
 
 Example test case with UDS:
 
-.. code-block::
-
-   *** Settings ***
-   Library           RobotFramework_UDS
-   Suite Setup       Connect
-   Suite Teardown    Disconnect
-
-   *** Variables ***
-   ${SUT_IP_ADDRESS}=         ecu_ip_address
-   ${SUT_LOGICAL_ADDRESS}=    ecu_logical_address
-   ${TB_IP_ADDRESS}=          client_ip_address
-   ${TB_LOGICAL_ADDRESS}=     client_logical_address
-   ${ACTIVATION_TYPE}=        0
-   ${NAME}=       UDS Connector
-
-   *** Keywords ***
-   Connect
-      Log    Create a uds Connector (DoIP) and establish the connection
-      ${uds}=    Create UDS Connector    ecu_ip_address= ${SUT_IP_ADDRESS}
-      ...                                ecu_logical_address= ${SUT_LOGICAL_ADDRESS}
-      ...                                client_ip_address= ${TB_IP_ADDRESS}
-      ...                                client_logical_address= ${TB_LOGICAL_ADDRESS}
-      ...                                activation_type= ${ACTIVATION_TYPE}
-      Connect UDS Connector    name=${Name}
-      Open UDS Connection
-
-   Disconnect
-      Log    Close uds connection
-      Close UDS Connection
-
-   *** Test Cases ***
-   Test user can use Tester Present service on ECU
-      Log    Use Tester Present service
-      ${response}=    Tester Present
+|   ``*** Settings ***``
+|   ``Library           RobotFramework_UDS``
+|   ``Suite Setup       Connect``
+|   ``Suite Teardown    Disconnect``
+|
+|   ``*** Variables ***``
+|   ``${SUT_IP_ADDRESS}=         ecu_ip_address``
+|   ``${SUT_LOGICAL_ADDRESS}=    ecu_logical_address``
+|   ``${TB_IP_ADDRESS}=          client_ip_address``
+|   ``${TB_LOGICAL_ADDRESS}=     client_logical_address``
+|   ``${ACTIVATION_TYPE}=        0``
+|   ``${NAME}=       UDS Connector``
+|
+|   ``*** Keywords ***``
+|   ``Connect``
+|      ``Log    Create a uds Connector (DoIP) and establish the connection``
+|      ``${uds}=    Create UDS Connector    ecu_ip_address= ${SUT_IP_ADDRESS}``
+|      ``...                                ecu_logical_address= ${SUT_LOGICAL_ADDRESS}``
+|      ``...                                client_ip_address= ${TB_IP_ADDRESS}``
+|      ``...                                client_logical_address= ${TB_LOGICAL_ADDRESS}``
+|      ``...                                activation_type= ${ACTIVATION_TYPE}``
+|      ``Connect UDS Connector    name=${Name}``
+|      ``Open UDS Connection``
+|
+|   ``Disconnect``
+|      ``Log    Close uds connection``
+|      ``Close UDS Connection``
+|
+|   ``*** Test Cases ***``
+|   ``Test user can use Tester Present service on ECU``
+|      ``Log    Use Tester Present service``
+|      ``${response}=    Tester Present``
 
 
 Please refer to `RobotFramework_UDS documentation <https://github.com/test-fullautomation/robotframework-uds/blob/develop/RobotFramework_UDS/RobotFramework_UDS.pdf>`_


### PR DESCRIPTION
Hi Thomas,

I just verified the generated release_info html file and forget to double check the changelog file.
This PR update the release info content to avoid the break line issue.

You do not need to rebuild all, just replace the content of Github Release by the new generated changelog file in `windows-aiotestlogfiles` of aio pipeline which is triggered by this PR.

Related to release email, I guess that you run the release_info tool manually from your side, is it right?
Please checkout this commit then run the tool.

Thank you,
Ngoan